### PR TITLE
New property "accepted_gift_types" in \aki\telegram\types\Chat

### DIFF
--- a/types/Chat.php
+++ b/types/Chat.php
@@ -110,6 +110,8 @@ class Chat extends Type
      */
     public $all_members_are_administrators;
 
+    public $accepted_gift_types;
+
     /**
     * Optional. True, if the supergroup chat is a forum (has topics enabled)
     */


### PR DESCRIPTION
When sending messages using `\aki\telegram\Telegram::sendMessage`, the `chat` object in the response now includes a new field `accepted_gift_types`, which currently causes the following exception:  
`yii\base\UnknownPropertyException: Setting unknown property: aki\telegram\types\Chat::accepted_gift_types`